### PR TITLE
Fog drone integration

### DIFF
--- a/config/control_interface.yaml
+++ b/config/control_interface.yaml
@@ -1,6 +1,6 @@
 param_namespace:
   # device_url: "serial:///dev/ttyS7:921600"
-  device_url: "udp://:14540"
+  device_url: "udp://:14590"
   takeoff_height: 3.0 # [m]
   waypoint_marker_scale: 0.3
   waypoint_loiter_time: 1.3 # [s]

--- a/launch/control_interface.py
+++ b/launch/control_interface.py
@@ -16,8 +16,9 @@ def generate_launch_description():
     ld.add_action(launch.actions.DeclareLaunchArgument("use_sim_time", default_value="false"))
 
     ld.add_action(launch.actions.DeclareLaunchArgument("debug", default_value="false"))
-    dbg_sub = launch.substitutions.PythonExpression(['"" if "false" == "', launch.substitutions.LaunchConfiguration("debug"), '" else "debug_ros2launch ' + os.ttyname(sys.stdout.fileno()) + '"'])
-
+    dbg_sub = None
+    if sys.stdout.isatty():
+        dbg_sub = launch.substitutions.PythonExpression(['"" if "false" == "', launch.substitutions.LaunchConfiguration("debug"), '" else "debug_ros2launch ' + os.ttyname(sys.stdout.fileno()) + '"'])
 
     DRONE_DEVICE_ID=os.getenv('DRONE_DEVICE_ID')
 

--- a/src/control_interface.cpp
+++ b/src/control_interface.cpp
@@ -234,16 +234,16 @@ ControlInterface::ControlInterface(rclcpp::NodeOptions options) : Node("control_
   diagnostics_publisher_     = this->create_publisher<fog_msgs::msg::ControlInterfaceDiagnostics>("~/diagnostics_out", 10);
 
   // subscribers
-  timesync_subscriber_ = this->create_subscription<px4_msgs::msg::Timesync>("~/timesync_in", 10, std::bind(&ControlInterface::timesyncCallback, this, _1));
-  gps_subscriber_      = this->create_subscription<px4_msgs::msg::VehicleGlobalPosition>("~/gps_in", 10, std::bind(&ControlInterface::gpsCallback, this, _1));
+  timesync_subscriber_ = this->create_subscription<px4_msgs::msg::Timesync>("~/timesync_in", rclcpp::SystemDefaultsQoS(), std::bind(&ControlInterface::timesyncCallback, this, _1));
+  gps_subscriber_      = this->create_subscription<px4_msgs::msg::VehicleGlobalPosition>("~/gps_in", rclcpp::SystemDefaultsQoS(), std::bind(&ControlInterface::gpsCallback, this, _1));
   pixhawk_odom_subscriber_ =
-      this->create_subscription<px4_msgs::msg::VehicleOdometry>("~/pixhawk_odom_in", 10, std::bind(&ControlInterface::pixhawkOdomCallback, this, _1));
+      this->create_subscription<px4_msgs::msg::VehicleOdometry>("~/pixhawk_odom_in", rclcpp::SystemDefaultsQoS(), std::bind(&ControlInterface::pixhawkOdomCallback, this, _1));
   control_mode_subscriber_ =
-      this->create_subscription<px4_msgs::msg::VehicleControlMode>("~/control_mode_in", 10, std::bind(&ControlInterface::controlModeCallback, this, _1));
+      this->create_subscription<px4_msgs::msg::VehicleControlMode>("~/control_mode_in", rclcpp::SystemDefaultsQoS(), std::bind(&ControlInterface::controlModeCallback, this, _1));
   land_detected_subscriber_ =
-      this->create_subscription<px4_msgs::msg::VehicleLandDetected>("~/land_detected_in", 10, std::bind(&ControlInterface::landDetectedCallback, this, _1));
+      this->create_subscription<px4_msgs::msg::VehicleLandDetected>("~/land_detected_in", rclcpp::SystemDefaultsQoS(), std::bind(&ControlInterface::landDetectedCallback, this, _1));
   mission_result_subscriber_ =
-      this->create_subscription<px4_msgs::msg::MissionResult>("~/mission_result_in", 10, std::bind(&ControlInterface::missionResultCallback, this, _1));
+      this->create_subscription<px4_msgs::msg::MissionResult>("~/mission_result_in", rclcpp::SystemDefaultsQoS(), std::bind(&ControlInterface::missionResultCallback, this, _1));
 
   // service handlers
   arming_service_         = this->create_service<std_srvs::srv::SetBool>("~/arming_in", std::bind(&ControlInterface::armingCallback, this, _1, _2));

--- a/src/control_interface.cpp
+++ b/src/control_interface.cpp
@@ -219,6 +219,9 @@ ControlInterface::ControlInterface(rclcpp::NodeOptions options) : Node("control_
     }
   }
 
+  if (!rclcpp::ok())
+    return;
+
   RCLCPP_INFO(this->get_logger(), "[%s]: Target connected", this->get_name());
   action_  = std::make_shared<mavsdk::Action>(system_);
   mission_ = std::make_shared<mavsdk::Mission>(system_);


### PR DESCRIPTION
Few fixes to make it work in fog drone:
- Udp connection to be done through mavlink-router which has dedicated port 14590 for control_interface.
- Launch file modified to support node launch also in case stdout is not a tty.
- Check ROS2 node running after exit from while loop which makes it exit properly without crash from "wait for conn" state.
- Use SystemDefaultsQoS for subscribing microRTPS topics to avoid reliability mismatch.
