### PR TITLE
Adding octomap reset

### DIFF
--- a/config/control_interface.yaml
+++ b/config/control_interface.yaml
@@ -2,5 +2,6 @@ param_namespace:
   # device_url: "serial:///dev/ttyS7:921600"
   device_url: "udp://:14590"
   takeoff_height: 1.0 # [m]
+  reset_octomap_before_takeoff: true
   waypoint_marker_scale: 0.3
   waypoint_loiter_time: 1.3 # [s]

--- a/launch/control_interface.py
+++ b/launch/control_interface.py
@@ -44,6 +44,8 @@ def generate_launch_description():
                     ("~/diagnostics_out", "~/diagnostics"),
                     ("~/debug_markers_out", "~/debug/waypoint_markers"),
 
+                    ("~/octomap_reset_out", "/" + DRONE_DEVICE_ID + "/octomap_server/reset"),
+
                     ("~/gps_in", "/" + DRONE_DEVICE_ID + "/VehicleGlobalPosition_PubSubTopic"),
                     ("~/pixhawk_odom_in", "/" + DRONE_DEVICE_ID + "/VehicleOdometry_PubSubTopic"),
                     ("~/control_mode_in", "/" + DRONE_DEVICE_ID + "/VehicleControlMode_PubSubTopic"),

--- a/src/control_interface.cpp
+++ b/src/control_interface.cpp
@@ -924,7 +924,7 @@ bool ControlInterface::takeoff() {
   if (reset_octomap_before_takeoff_) {
     auto reset_srv = std::make_shared<std_srvs::srv::Empty::Request>();
     auto call_result = octomap_reset_client_->async_send_request(reset_srv);
-    RCLCPP_INFO(this->get_logger(), "[%s]: Reseting octomap", this->get_name());
+    RCLCPP_INFO(this->get_logger(), "[%s]: Resetting octomap server", this->get_name());
   }
 
   action_->takeoff();


### PR DESCRIPTION
Control will now automatically reset the octomap before takeoff. The feature can be enabled/disabled by a parameter `reset_octomap_before_takeoff` in `config/control_interface.yaml`