### PR TITLE
Consider mission finished if last segment reached

### DIFF
--- a/src/control_interface.cpp
+++ b/src/control_interface.cpp
@@ -1078,7 +1078,19 @@ bool ControlInterface::takeoff() {
   current_goal.x   = pos_[1];
   current_goal.y   = pos_[0];
   current_goal.z   = takeoff_height_;
-  current_goal.yaw = getYaw(ori_) - yaw_offset_correction_;
+  tf2::Quaternion q_orig, q_rot, q_new;
+
+  q_orig.setW(ori_[0]);
+  q_orig.setX(ori_[1]);
+  q_orig.setY(ori_[2]);
+  q_orig.setZ(ori_[3]);
+
+  q_rot.setRPY(M_PI, 0, 0);
+  q_new = q_orig * q_rot;
+  q_new.normalize();
+  
+  current_goal.yaw = getYaw(tf2::toMsg(q_new));
+  //current_goal.yaw = getYaw(ori_) - yaw_offset_correction_;
   desired_pose_    = Eigen::Vector4d(current_goal.x, current_goal.y, current_goal.z, current_goal.yaw);
   waypoint_buffer_.push_back(current_goal);
   motion_started_ = true;

--- a/src/control_interface.cpp
+++ b/src/control_interface.cpp
@@ -514,6 +514,11 @@ void ControlInterface::missionResultCallback(const px4_msgs::msg::MissionResult:
     mission_finished_      = true;
     last_mission_instance_ = msg->instance_count;
   }
+  unsigned seq_remaining = msg->seq_total - msg->seq_current;
+  if (!msg->finished && instance_count != last_mission_instance_ && seq_remaining <= 1) {
+    mission_finished_      = true;
+    last_mission_instance_ = msg->instance_count;
+  }
 }
 //}
 


### PR DESCRIPTION
The PX4 takes quite a time to mark as mission finished in `/fmu/mission_result/out` topic. It seems to reach the final remaining segment of the mission, but it doesn't finish. 

The message values during the hovering at last waypoint;

seq_current: 55
seq_reached: 54
seq_total: 56

This fix is marking `mission_finished_` flag as `true` when the last segment is reached. This does not pause the mission on PX4, however letting `navigation` node to know that it is ready for new task. 

Navigation node sends diagnostic data to `mission-engine`. And when the last waypoint is reached, but not marked as finished, the `mission-engine` does not send the land command. Therefore, the drone just hovers over.

This is a quick dirty fix, however seems like it is more stable.