### PR TITLE
Run ros2 node as root inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,4 @@ ENV RMW_IMPLEMENTATION rmw_fastrtps_cpp
 
 WORKDIR /$PACKAGE_NAME
 ENTRYPOINT "/"$PACKAGE_NAME"/entrypoint.sh"
+USER root


### PR DESCRIPTION
Workaround to make ros2 node starting up properly in minikube environment for Dronsole simulation.
Real root cause of any possible missing permissions are not known yet.
